### PR TITLE
#19 #18, testing all moves in position

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -14,6 +14,7 @@ pub struct Position {
     pub col: i8,
 }
 
+#[derive(Clone)]
 pub struct Board {
     pub squares: [[Option<Piece>; BOARD_COLS as usize]; BOARD_ROWS as usize],
     pub move_turn: Color,

--- a/src/move_piece.rs
+++ b/src/move_piece.rs
@@ -234,3 +234,142 @@ impl Board {
         false
     }
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::board::*;
+
+    fn pos(r: i8, c: i8) -> Position { Position { row: r, col: c } }
+
+    // chat helped me we this i was lazy
+    fn fen_to_ascii_array(fen: &str) -> [String; 8] {
+        let mut rows: Vec<String> = Vec::new();
+
+        for row in fen.split('/') {
+            let mut expanded = String::new();
+
+            for ch in row.chars() {
+                if ch.is_ascii_digit() {
+                    let n = ch.to_digit(10).unwrap();
+                    for _ in 0..n {
+                        expanded.push('.');
+                    }
+                } else {
+                    expanded.push(ch);
+                }
+            }
+
+            rows.push(expanded);
+        }
+
+        assert_eq!(rows.len(), 8, "FEN must have 8 ranks");
+
+        rows.try_into().unwrap()
+    }
+
+    pub fn all_legal_moves(board: &Board) -> Vec<(Position, Position)> {
+        let mut legal_moves: Vec<(Position, Position)> = Vec::new();
+
+        for from_row in 0..BOARD_ROWS{
+            for from_col in 0..BOARD_COLS {
+                let from_pos = pos(from_row, from_col);
+
+                for to_row in 0..BOARD_ROWS {
+                    for to_col in 0..BOARD_COLS{
+                        let to_pos = pos(to_row, to_col);
+                        let mut tmp = board.clone();
+
+                        if tmp.move_piece(from_pos, to_pos).is_ok() {
+
+                            legal_moves.push((from_pos, to_pos));
+                        } else {
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+        legal_moves
+    }
+
+    fn dfs(b: &Board, d: usize, depth_total: usize, totals: &mut [usize]) {
+        let moves = all_legal_moves(b);
+        let idx = depth_total - d;
+        totals[idx] += moves.len();
+
+        if d == 1 { return; }
+
+        for (from, to) in moves {
+            let mut next = b.clone();
+            next.move_piece(from, to).unwrap();
+            dfs(&next, d - 1, depth_total, totals);
+        }
+    }
+
+    fn perft_layers(board: &mut Board, depth:usize) -> Vec<usize>{
+        assert!(depth >= 1);
+        let mut totals = vec![0usize; depth];
+        dfs(board, depth, depth, &mut totals);
+        totals
+    }
+
+    fn all_legal_moves_for_fen(fen: &str, depth:usize) -> Vec<usize>{
+        let mut board = Board::new();
+        let board_ascii = fen_to_ascii_array(fen);
+
+        // apperently we have to do this????? ofcourse chat helped me figure this out. but i think i get it
+        let mut board_ascii_refs: [&str; 8] = [
+            &board_ascii[0],
+            &board_ascii[1],
+            &board_ascii[2],
+            &board_ascii[3],
+            &board_ascii[4],
+            &board_ascii[5],
+            &board_ascii[6],
+            &board_ascii[7],
+        ];
+
+        board_ascii_refs.reverse();
+
+        board.setup_ascii(board_ascii_refs);
+
+        perft_layers(&mut board, depth)
+    }
+
+    #[test]
+    fn test_all_legal_moves_pos_1() {
+        let fen: &str = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR";
+        let expected: Vec<usize> = vec![20, 400, 8902];
+
+        let depth = 3;
+        let totals = all_legal_moves_for_fen(fen, depth);
+
+        assert_eq!(totals, expected);
+    }
+
+    #[test]
+    fn test_all_legal_moves_pos_2() {
+        // this test can only do 1 depth for now as it requires castles and en passants.
+        let fen: &str = "r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R";
+        let expected: Vec<usize> = vec![46, 2039, 97862]; 
+
+        let depth = 3;
+        let totals = all_legal_moves_for_fen(fen, depth);
+
+        assert_eq!(totals, expected);
+    }
+
+    #[test]
+    fn test_all_legal_moves_pos_3() {
+        // this test can only do 2 depth for now as it requires castles and en passants for the third.
+        let fen: &str = "8/2p5/3p4/KP5r/1R3p1k/8/4P1P1/8";
+        let expected: Vec<usize> = vec![14, 191, 2812]; 
+
+        let depth = 3;
+        let totals = all_legal_moves_for_fen(fen, depth);
+
+        assert_eq!(totals, expected);
+    }
+}


### PR DESCRIPTION
here we create a function to test all legal moves at a position. We then make a function with recursion that can try all moves for all previosly legal moves, giving us the amount of moves possible for a certain depth. generated simple function with gpt to translate fen strings to ascii structure to easily copy paste different positions from chess-programming-wiki