### PR TITLE
#8 En passant works (i think)

### DIFF
--- a/src/board.rs
+++ b/src/board.rs
@@ -20,6 +20,7 @@ pub struct Board {
     pub move_turn: Color,
     pub white_king: Option<Position>,
     pub black_king: Option<Position>, //cache the kings insted of looping through board looking for it??? good??
+    pub en_passant: Option<Position>
 }
 
 impl Board {
@@ -29,6 +30,7 @@ impl Board {
             move_turn: Color::White,
             white_king: None,
             black_king: None,
+            en_passant: None
         }
     }
 
@@ -61,6 +63,7 @@ impl Board {
         self.squares = [[None; BOARD_COLS as usize]; BOARD_ROWS as usize];
         self.white_king = None;
         self.black_king = None;
+        self.en_passant = None;
 
         for (row, row_str) in ascii.iter().enumerate() {
             for (col, ch) in row_str.chars().enumerate() {


### PR DESCRIPTION
ugly solution of en passant. As usual i will probably refactor later just want it to work. So now we let board have a memory of en_passant as a position. each time we move a piece two steps forward we will set en_passant to to_pos-direction position. wordy explained, but that works as we only will have one en_passant at the time. Then each move we check is en_passant, which checks for the piece moved is pawn, and that the move is capture movement. if it is en passant we will remove the piece that is en passanted, and keep it in memory look for checks, if check place everythin back as it was.